### PR TITLE
Testing deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Check that the values at the top of `scripts/provision.sh` are correct.
 Then run `scripts/provision.sh` to create the webapp and relevant resources.
 
 Instructions are given at the end of the script to run some manual steps that need to be performed through the Azure portal.
+These instructions will also give you the URL at which the site is hosted.
 
 If errors are encountered in the browser after deploy, the following settings can be added to web.config to display useful errors in the browser:
 ```


### PR DESCRIPTION
As requested in (https://github.com/alan-turing-institute/data-safe-haven/issues/82).

I've made some minor updates to the README to clarify some things that weren't initially clear to me. I see two outstanding issues:

1. When running `pytest` on the local setup, I get a lot of warnings of the form:

```python
/Users/jrobinson/.pyenv/versions/3.7.0/envs/dsh37-local/lib/python3.7/site-packages/whitenoise/base.py:104: UserWarning: No directory at: /Users/jrobinson/Projects/data-safe-haven-webapp/haven/staticfiles/
  warnings.warn(u'No directory at: {}'.format(root))
```
I couldn't work out which test was causing these or whether they're innocuous. Hopefully you can point me in the right direction @helenst?

2. The scripts directory (and hence `scripts/provision.sh`) is missing - can you add this? Either in this branch or in `start-webapp` which I can rebase onto?