### PR TITLE
Added missing roles for UserList (required for the UserRoleRequiredMixin

### DIFF
--- a/haven/identity/views.py
+++ b/haven/identity/views.py
@@ -103,6 +103,8 @@ class UserList(LoginRequiredMixin, UserRoleRequiredMixin, ListView):
     context_object_name = 'users'
     model = User
 
+    user_roles = [UserRole.SYSTEM_CONTROLLER, UserRole.RESEARCH_COORDINATOR]
+
     def get_queryset(self):
         return User.objects.get_visible_users(self.request.user)
 


### PR DESCRIPTION
Deployed webapp was not permitting list of users due to the Django model not including the required roles. Worked locally but not when deployed - this should now fix this for relevant roles (SYSTEM_CONTROLLER and RESEARCH_COORDINATOR).