### PR TITLE
Update clean() method to check whether project exists before validating

### DIFF
--- a/haven/projects/forms.py
+++ b/haven/projects/forms.py
@@ -49,10 +49,11 @@ class ProjectForUserInlineForm(SaveCreatorMixin, forms.ModelForm):
         fields = ('project', 'role')
 
     def clean(self):
-        project = self.cleaned_data['project']
-        role = ProjectRole(self.cleaned_data['role'])
-        if not self.user.project_role(project).can_assign_role(role):
-            raise ValidationError("You cannot assign the role on this project")
+        if 'project' in self.cleaned_data:
+            project = self.cleaned_data['project']
+            role = ProjectRole(self.cleaned_data['role'])
+            if not self.user.project_role(project).can_assign_role(role):
+                raise ValidationError("You cannot assign the role on this project")
 
 
 ProjectsForUserInlineFormSet = inlineformset_factory(


### PR DESCRIPTION
When editing user, deleting all the projects/roles, causes server error (500)

This error occurred when the Save User button was clicked following deletion of an empty role (a role that appears on the form but has not been filled in bu the user).
This happens because the validation code did check that the project field existed, which it does not in the case of an empty role entry being deleted.

Closes #19 