### PR TITLE
Referee classification of Tier 2+ data

### DIFF
--- a/haven/projects/roles.py
+++ b/haven/projects/roles.py
@@ -76,7 +76,7 @@ class ProjectRole(Enum):
     def can_classify_data(self):
         return self in [
             self.PROJECT_ADMIN,
-            self.RESEARCH_COORDINATOR,
+            self.REFEREE,
             self.DATA_PROVIDER_REPRESENTATIVE,
             self.INVESTIGATOR,
         ]

--- a/haven/projects/tests/test_models.py
+++ b/haven/projects/tests/test_models.py
@@ -42,12 +42,9 @@ class TestProject:
             role=ProjectRole.INVESTIGATOR.value, project=project)
         data_rep = recipes.participant.make(
             role=ProjectRole.DATA_PROVIDER_REPRESENTATIVE.value, project=project)
-        rc = recipes.participant.make(
-            role=ProjectRole.RESEARCH_COORDINATOR.value, project=project)
 
         project.classify_as(0, investigator.user)
         project.classify_as(0, data_rep.user)
-        project.classify_as(0, rc.user)
 
         assert project.is_classification_ready
         assert not project.tier_conflict
@@ -56,12 +53,9 @@ class TestProject:
 
     def test_classification_not_ready(self):
         project = recipes.project.make()
-        investigator = recipes.participant.make(
-            role=ProjectRole.INVESTIGATOR.value, project=project)
         data_rep = recipes.participant.make(
             role=ProjectRole.DATA_PROVIDER_REPRESENTATIVE.value, project=project)
 
-        project.classify_as(0, investigator.user)
         project.classify_as(0, data_rep.user)
 
         assert not project.is_classification_ready
@@ -73,12 +67,12 @@ class TestProject:
             role=ProjectRole.INVESTIGATOR.value, project=project)
         data_rep = recipes.participant.make(
             role=ProjectRole.DATA_PROVIDER_REPRESENTATIVE.value, project=project)
-        rc = recipes.participant.make(
-            role=ProjectRole.RESEARCH_COORDINATOR.value, project=project)
+        ref = recipes.participant.make(
+            role=ProjectRole.REFEREE.value, project=project)
 
         project.classify_as(2, investigator.user)
         project.classify_as(2, data_rep.user)
-        project.classify_as(2, rc.user)
+        project.classify_as(2, ref.user)
 
         assert project.is_classification_ready
         assert not project.tier_conflict
@@ -108,7 +102,7 @@ class TestProject:
             role=ProjectRole.RESEARCH_COORDINATOR.value, project=project)
 
         project.classify_as(0, investigator.user)
-        project.classify_as(0, data_rep.user)
+        project.classify_as(1, data_rep.user)
         project.classify_as(1, rc.user)
 
         assert project.is_classification_ready


### PR DESCRIPTION
Updated classification agreement to match the design doc. Only the DPR & Investigator initially have to classify the project, and if the DPR classifies it as Tier 2 or above then a Referee is needed as well. 

(The spec in one place says it only matter what the DPR says, and in another place says it matters what the Investigator says, but since if the Investigator says Tier 2 and the DPR doesn't then there isn't an agreement anyway, I don't think it matters for practical purposes).