### PR TITLE
Add own username/role in classification (fix #36)

### DIFF
--- a/haven/templates/projects/project_classify_results.html
+++ b/haven/templates/projects/project_classify_results.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 {% with classification.project as project %}
-<p>You have classified this project as Tier {{ classification.tier }}</p>
+<p>You ({{ classification.user }}, {{classification.user|project_role:project}}) have classified this project as Tier {{ classification.tier }}</p>
 
 {% if other_classifications.exists %}
   <ul>


### PR DESCRIPTION
Addresses #36. I imagine the role is more important, since most people would only have one username, but having both should make it easier for testing.