### PR TITLE
Fix tests and fix to function verifying access permissions for project participants.

### DIFF
--- a/haven/projects/views.py
+++ b/haven/projects/views.py
@@ -243,7 +243,8 @@ class ProjectClassifyData(
         return super().dispatch(*args, *kwargs)
 
     def test_func(self):
-        return self.get_project_participation_role().can_classify_data
+        role = self.get_project_participation_role()
+        return role.can_classify_data if role else False
 
     def done(self, form_list, **kwargs):
         """


### PR DESCRIPTION
Modify the test function used to validate access permissions to the classification page. This would have caused an exception when validating against a non-project participant, due to their project participation role being None. (#66 should fix this in a better way).

Research Coordinators no longer provide data classification so some of the classification view test were failing.
Changed classification view tests so that RCs create the test project but Data Provider Representatives provide the classification.

Added a tests to ensure RC as well as Researchers can no longer access the classification page.