### PR TITLE
Add option to delete a classification (fix #9)

### DIFF
--- a/haven/projects/forms.py
+++ b/haven/projects/forms.py
@@ -90,3 +90,7 @@ class ProjectAddDatasetForm(SaveCreatorMixin, forms.ModelForm):
     class Meta:
         model = Dataset
         fields = ('name', 'description')
+
+
+class ProjectClassifyDeleteForm(SaveCreatorMixin, forms.Form):
+    pass

--- a/haven/projects/models.py
+++ b/haven/projects/models.py
@@ -134,6 +134,11 @@ class Project(models.Model):
 
         return classification
 
+    def classification_for(self, user):
+        return self.classifications.filter(
+            user=user
+        )
+
     @property
     def has_tier(self):
         """Has this project's data been classified?"""

--- a/haven/projects/tests/test_views.py
+++ b/haven/projects/tests/test_views.py
@@ -426,6 +426,27 @@ class TestProjectClassifyData:
 
         assert 'wizard' not in response.context
 
+    def test_delete_classification(self, client, as_project_participant, research_coordinator):
+        insert_initial_questions(ClassificationQuestion)
+        project = recipes.project.make(created_by=research_coordinator)
+        project.add_user(username=as_project_participant._user.username,
+                         role=ProjectRole.DATA_PROVIDER_REPRESENTATIVE.value,
+                         creator=research_coordinator)
+        project.classify_as(0, as_project_participant._user)
+
+        response = as_project_participant.get('/projects/%d/classify' % project.id)
+        assert b'Delete My Classification' in response.content
+
+        response = as_project_participant.get('/projects/%d/classify_delete' % project.id)
+        assert b'Delete Classification' in response.content
+
+        response = as_project_participant.post('/projects/%d/classify_delete' % project.id, {})
+
+        response = as_project_participant.get('/projects/%d/classify' % project.id)
+        assert 'wizard' in response.context
+        assert b'Delete My Classification' not in response.content
+
+
     def test_classify_as_tier_0(self, as_project_participant, research_coordinator):
         insert_initial_questions(ClassificationQuestion)
         project = recipes.project.make(created_by=research_coordinator)

--- a/haven/projects/urls.py
+++ b/haven/projects/urls.py
@@ -44,4 +44,10 @@ urlpatterns = [
         views.ProjectClassifyData.as_view(),
         name='classify_data'
     ),
+
+    path(
+        '<int:pk>/classify_delete',
+        views.ProjectClassifyDelete.as_view(),
+        name='classify_delete'
+    ),
 ]

--- a/haven/templates/projects/project_classify_delete.html
+++ b/haven/templates/projects/project_classify_delete.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+
+{% block h1_title %}Delete Classification{% endblock %}
+
+{% block content %}
+<p>Please confirm below if you would like to delete your classification.</p>
+<form method="POST">
+  {% csrf_token %}
+  {{ form|crispy }}
+  <a href="{{ view.get_success_url }}" class="btn btn-secondary">Cancel</a>
+  <button type="submit" class="btn btn-danger">Delete Classification</button>
+</form>
+
+{% endblock content %}

--- a/haven/templates/projects/project_classify_results.html
+++ b/haven/templates/projects/project_classify_results.html
@@ -9,6 +9,10 @@
 {% with classification.project as project %}
 <p>You ({{ classification.user }}, {{classification.user|project_participation_role:project}}) have classified this project as Tier {{ classification.tier }}</p>
 
+{% if not project.has_tier %}
+  <p><a class="btn btn-primary btn-lg" href="{% url 'projects:classify_delete' project.id %}">Delete My Classification</a></p>
+{% endif %}
+
 {% if other_classifications.exists %}
   <ul>
   {% for cl in other_classifications %}


### PR DESCRIPTION
This adds the ability for a user to delete their own classification. I've left it so that it should only happen if a tier hasn't already been assigned, but that could always be relaxed if we decided it made sense. I also actually deleted it, rather than just marking it as deleted or similar since I'm not sure it's useful to keep them around, and since we're considering #69 anyway.