### PR TITLE
20 create user form should specify that valid phone number country code is required

### DIFF
--- a/haven/config/settings/base.py
+++ b/haven/config/settings/base.py
@@ -212,3 +212,5 @@ if EMAIL_HOST:
 DEFAULT_FROM_MAIL = env.str('FROM_MAIL', default='noreply@dsgroupdev.co.uk')
 
 SOCIAL_AUTH_LOGIN_ERROR_URL = '/error/'
+
+PHONENUMBER_DEFAULT_REGION = "GB"

--- a/haven/identity/forms.py
+++ b/haven/identity/forms.py
@@ -1,21 +1,37 @@
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
 from .mixins import SaveCreatorMixin
 from .models import User
-from .remote import create_user
 
 
 class CreateUserForm(SaveCreatorMixin, forms.ModelForm):
     class Meta:
         model = User
         fields = ['email', 'first_name', 'last_name', 'mobile']
-
+        widgets = {
+            'mobile': PhoneNumberInternationalFallbackWidget(
+                region=settings.PHONENUMBER_DEFAULT_REGION,
+                attrs={'class': 'form-control'}),
+        }
+        labels = {
+            'mobile': 'Mobile phone number',
+        }
+        help_texts = {
+            'mobile': 'International numbers must start with +',
+        }
+        error_messages = {
+            'mobile': {
+                'required': 'A mobile phone number is required.',
+                'invalid': 'Enter a valid UK or international phone number.',
+            },
+        }
     def clean_email(self):
         email = self.cleaned_data['email']
         if User.objects.filter(email=email).exists():
-            raise ValidationError("Email address already exists")
+            raise ValidationError("There is already a user with this email address.")
         return email
 
     def save(self, **kwargs):

--- a/haven/identity/tests/test_forms.py
+++ b/haven/identity/tests/test_forms.py
@@ -22,6 +22,40 @@ class TestCreateUserForm:
         assert form_user.created_by == system_controller
         assert form_user.username == 'test.user@example.com'
 
+    def test_create_user_with_uk_phone(self, system_controller, settings):
+        settings.SAFE_HAVEN_DOMAIN = 'example.com'
+        form = CreateUserForm({
+            'email': 'testuser@example.com',
+            'first_name': 'Test',
+            'last_name': 'User',
+            'mobile': '01234567890',
+        }, user=system_controller)
+        assert form.is_valid()
+        assert form.cleaned_data['mobile'] == '+441234567890'
+
+        form_user = form.save()
+
+        form_user.refresh_from_db()
+        assert form_user.created_by == system_controller
+        assert form_user.username == 'test.user@example.com'
+
+    def test_create_user_with_international_format(self, system_controller, settings):
+        settings.SAFE_HAVEN_DOMAIN = 'example.com'
+        form = CreateUserForm({
+            'email': 'testuser@example.com',
+            'first_name': 'Test',
+            'last_name': 'User',
+            'mobile': '+1-541-754-3010',
+        }, user=system_controller)
+        assert form.is_valid()
+        assert form.cleaned_data['mobile'] == '+15417543010'
+
+        form_user = form.save()
+
+        form_user.refresh_from_db()
+        assert form_user.created_by == system_controller
+        assert form_user.username == 'test.user@example.com'
+
     def test_retries_duplicate_username(self, system_controller, settings):
         settings.SAFE_HAVEN_DOMAIN = 'example.com'
         User.objects.create_user(email='a@b.com', username='test.user@example.com')
@@ -50,3 +84,23 @@ class TestCreateUserForm:
 
         assert not form.is_valid()
         assert 'email' in form.errors
+
+    def test_form_invalid_if_uk_number_invalid(self, system_controller, settings):
+        settings.SAFE_HAVEN_DOMAIN = 'example.com'
+        form = CreateUserForm({
+            'email': 'testuser@example.com',
+            'first_name': 'Test',
+            'last_name': 'User',
+            'mobile': '0123456789',
+        }, user=system_controller)
+        assert not form.is_valid()
+
+    def test_form_invalid_if_int_number_invalid(self, system_controller, settings):
+        settings.SAFE_HAVEN_DOMAIN = 'example.com'
+        form = CreateUserForm({
+            'email': 'testuser@example.com',
+            'first_name': 'Test',
+            'last_name': 'User',
+            'mobile': '+4412345678',
+        }, user=system_controller)
+        assert not form.is_valid()

--- a/haven/identity/views.py
+++ b/haven/identity/views.py
@@ -2,6 +2,7 @@ import csv
 
 import openpyxl
 from braces.views import UserFormKwargsMixin
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseRedirect, HttpResponse
@@ -193,8 +194,9 @@ def csv_users(lines):
         yield User(
             first_name=row['First Name'],
             last_name=row['Last Name'],
-            mobile=PhoneNumber.from_string(row['Mobile Phone'],
-                                           region='GB'),
+            mobile=PhoneNumber.from_string(
+                row['Mobile Phone'],
+                region=settings.PHONENUMBER_DEFAULT_REGION),
             email=row['Email']
         )
 
@@ -215,7 +217,8 @@ def xlsx_users(upload_file):
             yield User(
                 first_name=row_dict['First Name'],
                 last_name=row_dict['Last Name'],
-                mobile=PhoneNumber.from_string(row_dict['Mobile Phone'],
-                                               region='GB'),
+                mobile=PhoneNumber.from_string(
+                    row_dict['Mobile Phone'],
+                    region=settings.PHONENUMBER_DEFAULT_REGION),
                 email=row_dict['Email']
             )


### PR DESCRIPTION
Fixes #20. Adds a help comment when creating users that international numbers must start with +. Also permits UK numbers to be entered by assuming non-international numbers are in GB region. The region is cusomtisable in the settings.