### PR TITLE
Improved runbook for app registration

### DIFF
--- a/runbooks/create-management-webapp/azure-register-management-webapp.md
+++ b/runbooks/create-management-webapp/azure-register-management-webapp.md
@@ -1,45 +1,62 @@
 # Creating an Azure AD registration for the Data Safe Haven web management application
 
-These instructions are for System Managers to create an Azure AD registration for the management application.
+These instructions are for a System Manager to create an App Registration which allows the Data Safe Haven management web application to be deployed and run using Azure.
 
-This registration step only needs to be performed once; the webapp can be updated using the same app registration.
+This process will generate keys which should be stored in an Azure key vault. These keys will be required during deployment. The deployment process itself is covered in a separate runbook and can be performed by a different user, provided they have access to the key vault and appropriate Azure permissions.
 
-The actual deployment is described in a separate runbook. System Manager can delegate the actual deployment by storing the required
-deployment keys in a secure keyvault.
-
+This registration process only needs to be performed once per management application. Updating or redeployment of an existing application does not require a new registration.
 
 ## Prerequisites
 
 You will need
 
- * The desired name of the management webapp (`YOUR-WEBAPP-NAME`), which must be globally unique in Azure and will define the website address (e.g. `YOUR-WEBAPP-NAME.azurewebsites.net`).
- * Read/write access to the Azure subscription that will allow you to register the webapp (e.g. Data Safen Have Management subscription)
- * Write access to a keyvault which can be accessed by the users who will deploy the webapp.
+ * The new domain name of the management webapp (eg `YourSafeHaven`). This must be globally unique in Azure and will define the website address (eg `YourSafeHaven.azurewebsites.net`).
+ * The user-facing display name of the management webapp (eg `Your Safe Haven management application`).
+ * Permissions to create an App Registration on the appropriate Azure Active Directory.
+ * An Azure Key vault or equivalent secure location to store the keys so they can be accessed by the user performing the deployment.
 
+## Steps to register the Data Safe Haven management webapp
 
-### Register an app using the Azure Active Directory
+### Go to Azure
+ * Log into the Azure Portal
+ * Switch to the appropriate organisational directory where the app registration should be created (to change directory in Azure, click on your user icon at the top right and select "Switch Directory")
+### Create the App registration
+ * Open "Azure Active Directory" from the Azure menu on the left
+ * Open "App Registrations"
+ * Click "All Applications" and verify that a registration does not already exist for your webapp
+ * Click "New registration"
+ * Under "Name", enter the user-facing display name
+ * Under "Redirect URI" add the authentication endpoint as follows (replace YourSafeHaven with the domain name defined above, and ensure you include the trailing slash) `https://YourSafeHaven.azurewebsites.net/auth/complete/azuread-tenant-oauth2/`
+ * Click "Register"
+ * Select "Branding"
+ * Set the home page URL with the following, replacing YourSafeHaven with your domain defined above, e.g.`https://YourSafeHaven.azurewebsites.net`
+ * Click "Save".
+### Add permissions
+ * Open "API permissions"
+ * Click "Add a permission"
+ * Select "Microsoft Graph" from the Commonly used Microsoft APIs
+ * Select "Delegated permissions"
+ * For each of the following, search for the permission name and tick the checkbox to the left of the permission:
+   * `profile` (View users' basic profile)
+   * `email` (View users' email address)
+   * `Directory.Read.All` (Read directory data)
+   * `User.Read` (Sign in and read user profile)
+   * `Directory.AccessAsUser.All` (Access directory as the signed in user)
+ * Click "Add permissions". The above permissions should now appear in the list.
+ * Click "Grant admin consent for (your organisational directory name)"
+ * Click "Yes" to confirm. 
+### Create a key
+ * Open "Certificates and secrets"
+ * Click "New client secret"
+ * Enter "Description" as `App key`
+ * Select "Expires: never" 
+ * Click "Add"
+ * Copy the key value by clicking the copy icon nex to the value (you MUST do this now as you will not be able to read it later).
+ * Paste the key value as a new secret in your Azure key vault, giving it the name (replacing YourSafeHaven with your domain name defined above) `YourSafeHaven-app-key`
+## Copy application and tenant IDs
+ * In "App registrations", open your new registration and select "Overview"
+ * Copy the "Application (client) ID" and add as a new secret in your Azure key vault, giving it the name (replacing YourSafeHaven with your domain name defined above) `YourSafeHaven-application-id`
+ * Copy the "Directory (tenant) ID" and add as a new secret in your Azure key vault, giving it the name (replacing YourSafeHaven with your domain name defined above) `YourSafeHaven-tenant-id`
 
- * Log into the Azure Portal and switch to the directory for registering the application (click on your user icon and Switch Directory)
- * Choose Azure Active Directory/App Registrations
- * Click View All Applications and check that a registration does not already exist for your webapp
- * Click New Application Registration
- * Choose a suitable application name (eg. DSH web management development)
- * Under Redirect URI add the authentication endpoint (you must include the trailing slash) eg. https://YOUR-WEBAPP-NAME.azurewebsites.net/auth/complete/azuread-tenant-oauth2/
- * Click Register
- * Under Required Permissions add the following permissions for Microsoft Graph:
-   * Read directory data
-   * Sign in and read user profile
-   * Access directory as the signed in user
-   * View users' email address
-   * View users' basic profile
- * Under Certificates and secrets add a new client secret called "App key". Copy the value into the keyvault now, as you won't be able to read it later..
- * Under Overview copy the Application ID into the keyvault.
- * Under Branding set the home page URL eg,. https://YOUR-WEBAPP-NAME.azurewebsites.net/
- * Under Azure Active Directory/Properties, copy the Directory ID (also known as Tenant ID) into the keyvault.
-
-### Your keyvault should have the following values:
- * Application ID: the applicatin ID for the registration created above.
- * App key: the "App key" secret created above.
- * Directory ID: the AD Directory ID (also known as Tenant ID), which can be found under Azure Active Directory/Properties.
-
-Ensure the keyvault is accessible to the user who will deploy the app
+## Deploy the Safe Haven management webapp
+There is a separate runbook for this. Ensure the Key vault used above is accessible to the user who will deploy the app.


### PR DESCRIPTION
I think we can give this runbook to Ian or Warwick to create an app registration for the webapp production deployment. We may need to clarify wrt #85 (should a new key vault be created for each app or do we reuse one keyvault? If a new one is to be created, should that be included in the runbook instructions?)