### PR TITLE
 Add ability to edit project description

### DIFF
--- a/haven/projects/roles.py
+++ b/haven/projects/roles.py
@@ -86,6 +86,13 @@ class UserProjectPermissions:
                 ])
 
     @property
+    def can_edit(self):
+        """Is this role able to edit participants?"""
+        return self.is_project_admin or self.role in [
+            ProjectRole.PROJECT_MANAGER,
+        ]
+
+    @property
     def can_add_datasets(self):
         """Is this role able to add new datasets to the project?"""
         return self.is_project_admin or self.role in [

--- a/haven/projects/tests/test_roles.py
+++ b/haven/projects/tests/test_roles.py
@@ -113,6 +113,36 @@ class TestProjectRoleListParticipants:
         assert not perms.can_list_participants
 
 
+class TestProjectRoleEditProject:
+    def test_project_admin_can_edit(self):
+        perms = UserProjectPermissions(ProjectRole.RESEARCHER, UserRole.NONE, True)
+        assert perms.can_edit
+
+    def test_project_manager_can_edit(self):
+        perms = UserProjectPermissions(ProjectRole.PROJECT_MANAGER, UserRole.NONE, False)
+        assert perms.can_edit
+
+    def test_investigator_can_edit(self):
+        perms = UserProjectPermissions(ProjectRole.INVESTIGATOR, UserRole.NONE, False)
+        assert not perms.can_edit
+
+    def test_researcher_cannot_list_participants(self):
+        perms = UserProjectPermissions(ProjectRole.RESEARCHER, UserRole.NONE, False)
+        assert not perms.can_edit
+
+    def test_referee_cannot_list_participants(self):
+        perms = UserProjectPermissions(ProjectRole.REFEREE, UserRole.NONE, False)
+        assert not perms.can_edit
+
+    def test_programme_manager_can_edit(self):
+        perms = UserProjectPermissions(ProjectRole.RESEARCHER, UserRole.PROGRAMME_MANAGER, False)
+        assert not perms.can_edit
+
+    def test_system_manager_can_edit(self):
+        perms = UserProjectPermissions(ProjectRole.RESEARCHER, UserRole.SYSTEM_MANAGER, False)
+        assert not perms.can_edit
+
+
 class TestIsValidAssignableParticipantRole:
     def test_valid_roles(self):
         assert ProjectRole.is_valid_assignable_participant_role('referee')

--- a/haven/projects/tests/test_views.py
+++ b/haven/projects/tests/test_views.py
@@ -126,6 +126,71 @@ class TestViewProject:
 
 
 @pytest.mark.django_db
+class TestEditProject:
+    def test_anonymous_cannot_access_page(self, client, helpers):
+        response = client.get('/projects/1/edit')
+        helpers.assert_login_redirect(response)
+
+    def test_edit(self, as_project_participant):
+        project = recipes.project.make()
+        recipes.participant.make(project=project, user=as_project_participant._user,
+                                 role=ProjectRole.PROJECT_MANAGER.value)
+
+        response = as_project_participant.get('/projects/%d/edit' % project.id)
+
+        assert response.status_code == 200
+        assert response.context['project'] == project
+
+        response = as_project_participant.post('/projects/%d/edit' % project.id, {
+            'name': 'my updated project',
+            'description': 'a different project',
+        })
+
+        assert response.status_code == 302
+        assert response.url == '/projects/%d' % project.id
+
+        response = as_project_participant.get('/projects/%d' % project.id)
+
+        assert response.status_code == 200
+        assert response.context['project'].name == 'my updated project'
+        assert response.context['project'].description == 'a different project'
+
+    def test_view_owned_project(self, as_programme_manager):
+        project = recipes.project.make(created_by=as_programme_manager._user)
+
+        response = as_programme_manager.get('/projects/%d/edit' % project.id)
+
+        assert response.status_code == 200
+        assert response.context['project'] == project
+
+    def test_view_as_manager(self, as_project_participant):
+        project = recipes.project.make()
+        recipes.participant.make(project=project, user=as_project_participant._user,
+                                 role=ProjectRole.PROJECT_MANAGER.value)
+
+        response = as_project_participant.get('/projects/%d/edit' % project.id)
+
+        assert response.status_code == 200
+        assert response.context['project'] == project
+
+    def test_view_as_user(self, as_project_participant):
+        project = recipes.project.make()
+        recipes.participant.make(project=project, user=as_project_participant._user)
+
+        response = as_project_participant.get('/projects/%d/edit' % project.id)
+
+        assert response.status_code == 403
+
+    def test_view_as_system_manager(self, as_system_manager):
+        project = recipes.project.make()
+
+        response = as_system_manager.get('/projects/%d' % project.id)
+
+        assert response.status_code == 200
+        assert response.context['project'] == project
+
+
+@pytest.mark.django_db
 class TestAddUserToProject:
     def test_anonymous_cannot_access_page(self, client, helpers):
         project = recipes.project.make()

--- a/haven/projects/urls.py
+++ b/haven/projects/urls.py
@@ -16,6 +16,12 @@ urlpatterns = [
     ),
 
     path(
+        '<int:pk>/edit',
+        views.ProjectEdit.as_view(),
+        name='edit'
+    ),
+
+    path(
         '<int:pk>/participants/',
         views.ProjectListParticipants.as_view(),
         name='list_participants'

--- a/haven/projects/views.py
+++ b/haven/projects/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import DetailView, ListView
 from django.views.generic.detail import SingleObjectMixin
-from django.views.generic.edit import CreateView, FormMixin
+from django.views.generic.edit import CreateView, FormMixin, UpdateView
 from django_tables2 import SingleTableMixin
 from formtools.wizard.views import SessionWizardView
 
@@ -98,6 +98,21 @@ class ProjectDetail(LoginRequiredMixin, SingleProjectMixin, DetailView, SingleTa
         table = self.get_table(**self.get_table_kwargs())
         context[self.get_context_table_name(table)] = table
         return context
+
+
+class ProjectEdit(
+    LoginRequiredMixin, UserPassesTestMixin,
+    SingleProjectMixin, UserFormKwargsMixin, UpdateView
+):
+    model = Project
+    form_class = ProjectForm
+
+    def test_func(self):
+        return self.get_project_role().can_edit
+
+    def get_success_url(self):
+        obj = self.get_object()
+        return reverse('projects:detail', args=[obj.id])
 
 
 class ProjectAddUser(

--- a/haven/templates/projects/project_detail.html
+++ b/haven/templates/projects/project_detail.html
@@ -17,6 +17,12 @@ Role: {{ participant.get_role_display }}
 </p>
 
 <div class="my-3" role="group">
+  {% if project_role.can_edit %}
+    <a class="btn btn-primary btn-lg" href="{% url 'projects:edit' project.id %}">Edit</a>
+  {% endif %}
+</div>
+
+<div class="my-3" role="group">
   {% if project_role.can_list_participants %}
     <a class="btn btn-primary btn-lg" href="{% url 'projects:list_participants' project.id %}">Participants</a>
   {% endif %}


### PR DESCRIPTION
This addresses #94. I've also left in the ability to edit the project name, as I can't think of any reason a project manager shouldn't be able to do that.