### PR TITLE
Add cancel buttons (#61)

### DIFF
--- a/haven/projects/views.py
+++ b/haven/projects/views.py
@@ -71,6 +71,12 @@ class ProjectCreate(
     def get_success_url(self):
         return reverse('projects:list')
 
+    def post(self, request, *args, **kwargs):
+        if "cancel" in request.POST:
+            url = self.get_success_url()
+            return HttpResponseRedirect(url)
+        return super().post(request, *args, **kwargs)
+
 
 class ProjectList(LoginRequiredMixin, ListView):
     context_object_name = 'projects'
@@ -113,6 +119,12 @@ class ProjectEdit(
     def get_success_url(self):
         obj = self.get_object()
         return reverse('projects:detail', args=[obj.id])
+
+    def post(self, request, *args, **kwargs):
+        if "cancel" in request.POST:
+            url = self.get_success_url()
+            return HttpResponseRedirect(url)
+        return super().post(request, *args, **kwargs)
 
 
 class ProjectAddUser(
@@ -256,6 +268,10 @@ class ProjectCreateDataset(
     form_class = ProjectAddDatasetForm
 
     def post(self, request, *args, **kwargs):
+        if "cancel" in request.POST:
+            url = self.get_success_url()
+            return HttpResponseRedirect(url)
+
         form = self.get_form()
         self.object = self.get_object()
         if form.is_valid():

--- a/haven/templates/projects/project_add_dataset.html
+++ b/haven/templates/projects/project_add_dataset.html
@@ -6,8 +6,7 @@
 {% block content %}
 <form method="POST">
   {% csrf_token %}
-  {{ form|crispy }}
-  <button type="submit" class="btn btn-success">Create Dataset</button>
+  {% crispy form %}
 </form>
 
 {% endblock content %}

--- a/haven/templates/projects/project_form.html
+++ b/haven/templates/projects/project_form.html
@@ -12,8 +12,7 @@
 {% block content %}
 <form method="POST">
   {% csrf_token %}
-  {{ form|crispy }}
-  <button type="submit" class="btn btn-success">Save Project</button>
+  {% crispy form %}
 </form>
 
 {% endblock content %}


### PR DESCRIPTION
This adds cancel buttons to the forms that were missing them (project create/edit & adding datasets), and makes the order of buttons consistent (delete classification had cancel first). I also fixed a few issues with breadcrumbs/titles that I noticed.