### PR TITLE
Allow Programme Managers to view and edit all projects, and import/export users

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,6 +51,16 @@ def programme_manager():
 
 
 @pytest.fixture
+def standard_user():
+    return User.objects.create_user(
+        username='user@example.com',
+        email='user@example.com',
+        role=UserRole.NONE.value,
+        password=DUMMY_PASSWORD,
+    )
+
+
+@pytest.fixture
 def project_participant():
     return User.objects.create_user(
         first_name='Angela',
@@ -111,6 +121,11 @@ def as_system_manager(client, system_manager):
 @pytest.fixture
 def as_programme_manager(client, programme_manager):
     return client_login(client, programme_manager)
+
+
+@pytest.fixture
+def as_standard_user(client, standard_user):
+    return client_login(client, standard_user)
 
 
 @pytest.fixture

--- a/haven/identity/models.py
+++ b/haven/identity/models.py
@@ -134,6 +134,7 @@ class User(AbstractUser):
 
         is_project_admin = self.is_superuser or \
             self.user_role is UserRole.SYSTEM_MANAGER or \
+            self.user_role is UserRole.PROGRAMME_MANAGER or \
             self == project.created_by
         return UserProjectPermissions(project_role, self.user_role, is_project_admin)
 

--- a/haven/identity/roles.py
+++ b/haven/identity/roles.py
@@ -63,6 +63,7 @@ class UserRole(Enum):
         """Can a user with this role view all projects?"""
         return self in [
             self.SUPERUSER,
+            self.PROGRAMME_MANAGER,
             self.SYSTEM_MANAGER,
         ]
 
@@ -71,6 +72,7 @@ class UserRole(Enum):
         """Can a user with this role edit all projects?"""
         return self in [
             self.SUPERUSER,
+            self.PROGRAMME_MANAGER,
             self.SYSTEM_MANAGER,
         ]
 
@@ -88,6 +90,7 @@ class UserRole(Enum):
         """Can a user with this role create other users?"""
         return self in [
             self.SUPERUSER,
+            self.PROGRAMME_MANAGER,
             self.SYSTEM_MANAGER,
         ]
 
@@ -105,6 +108,7 @@ class UserRole(Enum):
         """Can a user with this role export a user list?"""
         return self in [
             self.SUPERUSER,
+            self.PROGRAMME_MANAGER,
             self.SYSTEM_MANAGER,
         ]
 
@@ -113,6 +117,7 @@ class UserRole(Enum):
         """Can a user with this role create users from an imported file?"""
         return self in [
             self.SUPERUSER,
+            self.PROGRAMME_MANAGER,
             self.SYSTEM_MANAGER,
         ]
 

--- a/haven/identity/tests/test_models.py
+++ b/haven/identity/tests/test_models.py
@@ -57,11 +57,11 @@ class TestUser:
         assert programme_manager.get_participant(project).user == programme_manager
         assert programme_manager.project_participation_role(project) is ProjectRole.INVESTIGATOR
 
-    def test_project_owner_does_not_get_admin_on_other_project_when_not_participating(self, programme_manager):
-        recipes.project.make(created_by=programme_manager)
+    def test_project_owner_does_not_get_admin_on_other_project_when_not_participating(self, standard_user):
+        recipes.project.make(created_by=standard_user)
         project = recipes.project.make()
-        assert not programme_manager.project_role(project).is_project_admin
-        assert programme_manager.project_participation_role(project) is None
+        assert not standard_user.project_role(project).is_project_admin
+        assert standard_user.project_participation_role(project) is None
 
     def test_project_owner_does_not_get_role_on_other_project_when_not_participating(self, programme_manager):
         recipes.project.make(created_by=programme_manager)
@@ -69,11 +69,11 @@ class TestUser:
         assert programme_manager.get_participant(project) is None
         assert programme_manager.project_participation_role(project) is None
 
-    def test_project_owner_does_not_get_admin_on_other_project_when_participating(self, programme_manager):
-        recipes.project.make(created_by=programme_manager)
+    def test_project_owner_does_not_get_admin_on_other_project_when_participating(self, standard_user):
+        recipes.project.make(created_by=standard_user)
         project = recipes.project.make()
-        project.add_user(user=programme_manager, role=ProjectRole.INVESTIGATOR.value, creator=programme_manager)
-        assert not programme_manager.project_role(project).is_project_admin
+        project.add_user(user=standard_user, role=ProjectRole.INVESTIGATOR.value, creator=standard_user)
+        assert not standard_user.project_role(project).is_project_admin
 
     def test_project_role_is_None_for_non_involved_project(self, researcher):
         assert researcher.user.project_role(recipes.project.make()).role is None

--- a/haven/identity/tests/test_roles.py
+++ b/haven/identity/tests/test_roles.py
@@ -8,8 +8,8 @@ class TestUserRoleCreateUser:
     def test_system_manager_can_create_users(self):
         assert UserRole.SYSTEM_MANAGER.can_create_users
 
-    def test_programme_manager_cannot_create_users(self):
-        assert not UserRole.PROGRAMME_MANAGER.can_create_users
+    def test_programme_manager_can_create_users(self):
+        assert UserRole.PROGRAMME_MANAGER.can_create_users
 
     def test_unprivileged_user_cannot_create_users(self):
         assert not UserRole.NONE.can_create_users
@@ -19,14 +19,17 @@ class TestUserRoleCreatableRoles:
     def test_superuser_can_create_any_roles(self):
         assert UserRole.SUPERUSER.can_create(UserRole.SYSTEM_MANAGER)
         assert UserRole.SUPERUSER.can_create(UserRole.PROGRAMME_MANAGER)
+        assert UserRole.SUPERUSER.can_create(UserRole.NONE)
 
     def test_system_manager_creatable_roles(self):
         assert UserRole.SYSTEM_MANAGER.can_create(UserRole.PROGRAMME_MANAGER)
+        assert UserRole.SYSTEM_MANAGER.can_create(UserRole.NONE)
         assert not UserRole.SYSTEM_MANAGER.can_create(UserRole.SYSTEM_MANAGER)
 
     def test_programme_manager_creatable_roles(self):
-        assert UserRole.PROGRAMME_MANAGER.creatable_roles == []
-        assert not UserRole.PROGRAMME_MANAGER.can_create(UserRole.NONE)
+        assert UserRole.PROGRAMME_MANAGER.can_create(UserRole.NONE)
+        assert not UserRole.PROGRAMME_MANAGER.can_create(UserRole.PROGRAMME_MANAGER)
+        assert not UserRole.PROGRAMME_MANAGER.can_create(UserRole.SYSTEM_MANAGER)
 
     def test_unprivileged_user_has_no_creatable_roles(self):
         assert UserRole.NONE.creatable_roles == []
@@ -54,8 +57,8 @@ class TestUserRoleViewAllProjects:
     def test_system_manager_can_view_all_projects(self):
         assert UserRole.SYSTEM_MANAGER.can_view_all_projects
 
-    def test_programme_manager_cannot_view_all_projects(self):
-        assert not UserRole.PROGRAMME_MANAGER.can_view_all_projects
+    def test_programme_manager_can_view_all_projects(self):
+        assert UserRole.PROGRAMME_MANAGER.can_view_all_projects
 
     def test_unprivileged_user_cannot_view_all_projects(self):
         assert not UserRole.NONE.can_view_all_projects
@@ -82,8 +85,8 @@ class TestUserRoleImportUsers:
     def test_system_manager_can_import_users(self):
         assert UserRole.SYSTEM_MANAGER.can_import_users
 
-    def test_programme_manager_cannot_import_users(self):
-        assert not UserRole.PROGRAMME_MANAGER.can_import_users
+    def test_programme_manager_can_import_users(self):
+        assert UserRole.PROGRAMME_MANAGER.can_import_users
 
     def test_unprivileged_user_cannot_import_users(self):
         assert not UserRole.NONE.can_import_users
@@ -96,8 +99,8 @@ class TestUserRoleExportUsers:
     def test_system_manager_can_export_users(self):
         assert UserRole.SYSTEM_MANAGER.can_export_users
 
-    def test_programme_manager_cannot_export_users(self):
-        assert not UserRole.PROGRAMME_MANAGER.can_export_users
+    def test_programme_manager_can_export_users(self):
+        assert UserRole.PROGRAMME_MANAGER.can_export_users
 
     def test_unprivileged_user_cannot_export_users(self):
         assert not UserRole.NONE.can_export_users

--- a/haven/projects/tests/test_views.py
+++ b/haven/projects/tests/test_views.py
@@ -48,11 +48,11 @@ class TestListProjects:
         response = client.get('/projects/')
         helpers.assert_login_redirect(response)
 
-    def test_list_owned_projects(self, as_programme_manager, system_manager):
-        my_project = recipes.project.make(created_by=as_programme_manager._user)
+    def test_list_owned_projects(self, as_standard_user, system_manager):
+        my_project = recipes.project.make(created_by=as_standard_user._user)
         recipes.project.make(created_by=system_manager)
 
-        response = as_programme_manager.get('/projects/')
+        response = as_standard_user.get('/projects/')
 
         assert list(response.context['projects']) == [my_project]
 
@@ -97,10 +97,10 @@ class TestViewProject:
         assert response.status_code == 200
         assert response.context['project'] == project1
 
-    def test_cannot_view_other_project(self, as_programme_manager):
+    def test_cannot_view_other_project(self, as_standard_user):
         project = recipes.project.make()
 
-        response = as_programme_manager.get('/projects/%d' % project.id)
+        response = as_standard_user.get('/projects/%d' % project.id)
 
         assert response.status_code == 404
 
@@ -137,11 +137,11 @@ class TestViewWorkPackage:
 
         assert response.status_code == 404
 
-    def test_cannot_view_other_project(self, as_programme_manager):
+    def test_cannot_view_other_project(self, as_standard_user):
         project = recipes.project.make()
         work_package = recipes.work_package.make(project=project)
 
-        response = as_programme_manager.get('/projects/%d/work_packages/%d'
+        response = as_standard_user.get('/projects/%d/work_packages/%d'
                                             % (project.id, work_package.id))
 
         assert response.status_code == 404
@@ -303,15 +303,15 @@ class TestAddUserToProject:
 
         assert project.participant_set.count() == 0
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
 
         # Programme manager shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get('/projects/%d/participants/add' % project.id)
+        response = as_standard_user.get('/projects/%d/participants/add' % project.id)
         assert response.status_code == 404
 
-        response = as_programme_manager.post('/projects/%d/participants/add' % project.id)
+        response = as_standard_user.post('/projects/%d/participants/add' % project.id)
         assert response.status_code == 404
 
     def test_returns_403_if_no_add_permissions(self, client, researcher):
@@ -355,12 +355,12 @@ class TestListParticipants:
         assert response.status_code == 200
         assert list(response.context['ordered_participants']) == [investigator, researcher]
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
 
         # Programme manager shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get('/projects/%d/participants/' % project.id)
+        response = as_standard_user.get('/projects/%d/participants/' % project.id)
         assert response.status_code == 404
 
     def test_returns_403_for_unauthorised_user(self, client, researcher):
@@ -420,15 +420,15 @@ class TestProjectAddDataset:
         assert response.status_code == 200
         assert project.datasets.count() == 0
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
 
         # Programme manager shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get('/projects/%d/datasets/new' % project.id)
+        response = as_standard_user.get('/projects/%d/datasets/new' % project.id)
         assert response.status_code == 404
 
-        response = as_programme_manager.post('/projects/%d/datasets/new' % project.id)
+        response = as_standard_user.post('/projects/%d/datasets/new' % project.id)
         assert response.status_code == 404
 
     def test_returns_403_if_no_add_permissions(self, client, researcher):
@@ -464,12 +464,12 @@ class TestListDatasets:
         assert response.status_code == 200
         assert list(response.context['datasets']) == [ds1, ds2]
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
 
-        # Programme manager shouldn't have visibility of this other project at all
+        # Regular user shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get('/projects/%d/datasets/' % project.id)
+        response = as_standard_user.get('/projects/%d/datasets/' % project.id)
         assert response.status_code == 404
 
 
@@ -560,15 +560,15 @@ class TestProjectAddWorkPackage:
         assert project.work_packages.first().name == 'work package 1'
         assert project.work_packages.first().description == 'Work Package One'
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
 
         # Programme manager shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get('/projects/%d/work_packages/new' % project.id)
+        response = as_standard_user.get('/projects/%d/work_packages/new' % project.id)
         assert response.status_code == 404
 
-        response = as_programme_manager.post('/projects/%d/work_packages/new' % project.id)
+        response = as_standard_user.post('/projects/%d/work_packages/new' % project.id)
         assert response.status_code == 404
 
     def test_returns_403_if_no_add_permissions(self, client, researcher):
@@ -601,12 +601,12 @@ class TestListWorkPackages:
         assert response.status_code == 200
         assert list(response.context['work_packages']) == [wp1, wp2]
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
 
         # Programme manager shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get('/projects/%d/work_packages/' % project.id)
+        response = as_standard_user.get('/projects/%d/work_packages/' % project.id)
         assert response.status_code == 404
 
 
@@ -637,16 +637,16 @@ class TestWorkPackageClassifyData:
         assert response.context['work_package'] == work_package
         assert 'wizard' in response.context
 
-    def test_returns_404_for_invisible_project(self, as_programme_manager):
+    def test_returns_404_for_invisible_project(self, as_standard_user):
         project = recipes.project.make()
         work_package = recipes.work_package.make(project=project)
 
         # Programme manager shouldn't have visibility of this other project at all
         # so pretend it doesn't exist and raise a 404
-        response = as_programme_manager.get(self.url(work_package))
+        response = as_standard_user.get(self.url(work_package))
         assert response.status_code == 404
 
-        response = as_programme_manager.post(self.url(work_package))
+        response = as_standard_user.post(self.url(work_package))
         assert response.status_code == 404
 
     def test_returns_403_for_researcher(self, client, researcher):


### PR DESCRIPTION
This appears to be the current spec in the paper, where Programme Managers can create users (and hence import/export), and can view and manage all projects.