### PR TITLE
Allow appropriate users to unassign (ie set to None) as well as assign system roles

### DIFF
--- a/haven/identity/roles.py
+++ b/haven/identity/roles.py
@@ -51,10 +51,12 @@ class UserRole(Enum):
             return [
                 self.SYSTEM_MANAGER,
                 self.PROGRAMME_MANAGER,
+                self.NONE,
             ]
         elif self is self.SYSTEM_MANAGER:
             return [
                 self.PROGRAMME_MANAGER,
+                self.NONE,
             ]
         return []
 

--- a/haven/identity/tests/test_roles.py
+++ b/haven/identity/tests/test_roles.py
@@ -19,9 +19,11 @@ class TestUserRoleCreatableRoles:
     def test_superuser_can_create_any_roles(self):
         assert UserRole.SUPERUSER.can_create(UserRole.SYSTEM_MANAGER)
         assert UserRole.SUPERUSER.can_create(UserRole.PROGRAMME_MANAGER)
+        assert UserRole.SUPERUSER.can_create(UserRole.NONE)
 
     def test_system_manager_creatable_roles(self):
         assert UserRole.SYSTEM_MANAGER.can_create(UserRole.PROGRAMME_MANAGER)
+        assert UserRole.SYSTEM_MANAGER.can_create(UserRole.NONE)
         assert not UserRole.SYSTEM_MANAGER.can_create(UserRole.SYSTEM_MANAGER)
 
     def test_programme_manager_creatable_roles(self):


### PR DESCRIPTION
Add ability to assign "None" role to users. Previously, it wasn't possible to unassign a Programme Manager role from a user