### PR TITLE
Fix issue #118: change to global user role does not persist in database

### DIFF
--- a/haven/identity/pipeline.py
+++ b/haven/identity/pipeline.py
@@ -48,7 +48,14 @@ def determine_role(backend, user, response, *args, **kwargs):
     graph = user_client(user)
     graph_response = graph.get_my_memberships()
 
-    role = UserRole(user.role) if user.role else UserRole.NONE
+    # Default user role to none
+    role = UserRole.NONE
+
+    # Preserve previous role unless System Manager
+    if user.role and user.role != UserRole.SYSTEM_MANAGER.value:
+        role = user.role
+
+    # System Manager is only set by beiong a member of the appropriate group
     if graph_response.ok:
         groups = graph_response.json().get('value', [])
         for group in groups:


### PR DESCRIPTION
It turned out the problem was that the system role is dynamically set to either None or to System Manager if the user was a member of the appropriate Graph group. In the case of Programme Manager there is no corresponding group so the system role just gets set to None.

I've changed this so that the system role is preserved, with the exception of System Manager which is still determined by the groups. I think this is probably the behaviour we expect but would be open to discussion.