### PR TITLE
(WIP) Add Docker container for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,239 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+#build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage.*
+.cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+
+### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### SublimeText template
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+
+### macOS template
+# General
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Vim template
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+pyvenv.cfg
+pip-selfcheck.json
+
+
+# Even though the project might be opened and edited
+# in any of the JetBrains IDEs, it makes no sence whatsoever
+# to 'run' anything within it since any particular cookiecutter
+# is declarative by nature.
+.idea/
+
+.pytest_cache/
+
+.coverage
+coverage/
+
+# npm installs
+node_modules/
+haven/staticfiles
+haven/static/build/
+
+# documentation
+runbooks/
+
+# generated files
+schemaspy/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:10-stretch AS build-js
+
+RUN npm install -g gulp-cli
+
+COPY ./haven/static .
+RUN npm install
+
+RUN gulp
+
+FROM python:3.7-stretch AS prod
+
+RUN apt-get update \
+    && apt-get install --assume-yes \
+      build-essential \
+      unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/site/repository
+
+COPY requirements/ ./requirements/
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install gunicorn
+
+COPY haven/ haven/
+COPY deploy_linux.sh deploy_linux.sh
+COPY --from=build-js build/ haven/static/build/
+
+CMD /home/site/repository/deploy_linux.sh
+
+FROM debian:stretch AS build-dockerize
+
+RUN apt-get update \
+    && apt-get install --assume-yes \
+      wget \
+    && rm -rf /var/lib/apt/lists/*
+  
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+FROM prod AS dev
+
+COPY --from=build-dockerize /usr/local/bin/dockerize /usr/local/bin/dockerize
+CMD dockerize -wait tcp://db:5432 /home/site/repository/deploy_linux.sh

--- a/deploy_linux.sh
+++ b/deploy_linux.sh
@@ -20,6 +20,7 @@ mkdir -p /home/site/repository/staticfiles
 python3 haven/manage.py collectstatic --noinput --clear
 
 echo "Running Safe Haven migrations..."
+python3 haven/manage.py migrate easyaudit
 python3 haven/manage.py migrate
 
 echo "Running gunicorn web server..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.4'
+services:
+
+  app:
+    build:
+      context: .
+      target: dev
+#     volumes:
+#       - .:/home/site/repository
+    ports:
+      - "${APP_BIND_ADDRESS}:8000"
+    env_file: .env
+
+  db:
+    image: postgres:10.7
+    restart: always
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    env_file: .env
+
+volumes:
+  db_data:

--- a/runbooks/development/set-up-local-docker.md
+++ b/runbooks/development/set-up-local-docker.md
@@ -1,0 +1,58 @@
+# Data Safe Haven web management application
+
+These instructions are for running a local test instance of the management web application on your machine, using Docker and Docker Compose.
+This is closer to how the application runs in production. 
+It could also be used for local development, although there are several enhancements required to make that smooth (bind-mount source files, gunicorn/npm auto-reload etc.).
+
+## Local Development Setup
+
+### Install system requirements
+
+* Docker (tested with 19.03)
+* docker-compose (tested with 1.22)
+
+### Set up environment variables
+
+Create a file named `.env` with the following entries:
+
+```python
+# A randomly generated string
+SECRET_KEY='my-secret-key'
+
+# Address you wish the app to be available on
+APP_BIND_ADDRESS=127.0.0.1:8000
+
+# This should match APP_BIND_ADDRESS
+ALLOWED_HOSTS=127.0.0.1
+
+# Credentials used in creating Postgres database 
+POSTGRES_USER=haven
+POSTGRES_PASSWORD=my-password
+
+# Database connection should match above credentials
+DATABASE_URL=postgres://haven:my-password@db:5432/haven
+
+# Config file you want to use
+DJANGO_SETTINGS_MODULE=config.settings.local
+```
+
+Note that if you also have a `haven/.env` file (for local development without Docker), most values can be set in either `.env` or `haven/.env`.
+The exceptions are any specifically needed by docker-compose, e.g. `APP_BIND_ADDRESS` or by Postgres, e.g. `POSTGRES_USER`.
+If values are set in both files, `.env` takes precedence.
+
+## Run server
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+### Create initial admin user account
+
+```bash
+docker-compose exec app haven/manage.py createsuperuser
+```
+
+## Accessing the test server
+
+The local server can be accessed at the address you specify in `.env`, e.g. `http://127.0.0.1:8000/`.


### PR DESCRIPTION
This is work to support #109 - removing the built JS files from the project. I have not actually removed the artifacts yet, but the image that's produced here doesn't use them. 

In theory therefore, this should work, but I think we need more infrastructure in place to support it, particularly:
* Somewhere to hold the image, probably an Azure Container Registry (as in https://docs.microsoft.com/en-gb/azure/app-service/containers/tutorial-custom-docker-image)
* Something to build and push the image (possibly Travis or Github actions)

This custom container also doesn't contain an SSH server like the built-in Azure one. It's not clear to me why exactly you need one, but it's possible something in Azure relies on it