### PR TITLE
Project user export

### DIFF
--- a/haven/identity/tests/test_views.py
+++ b/haven/identity/tests/test_views.py
@@ -294,6 +294,24 @@ class TestExportUsers:
             ['user1', '', '', '', 'user@example.com'],
         ]
 
+    def test_export_by_project(self, as_programme_manager, superuser, system_manager, standard_user,
+                               project_participant, user1):
+        project = recipes.project.make(created_by=as_programme_manager._user)
+        project.add_user(user1, role=ProjectRole.PROJECT_MANAGER.value,
+                         creator=as_programme_manager._user)
+        project.add_user(project_participant, role=ProjectRole.RESEARCHER.value,
+                         creator=as_programme_manager._user)
+        response = as_programme_manager.get(f"/users/export?project={project.pk}")
+        assert response.status_code == 200
+        assert response['Content-Type'] == 'text/csv'
+        parsed = self.parse_csv_response(response)
+        assert parsed == [
+            ['SamAccountName', 'GivenName', 'Surname', 'Mobile', 'SecondaryEmail'],
+            ['user1', '', '', '', 'user@example.com'],
+            ['project_participant', 'Angela', 'Zala', '+441234567890',
+             'project_participant@example.com'],
+        ]
+
 
 @pytest.mark.django_db
 class TestImportUsers:

--- a/haven/identity/views.py
+++ b/haven/identity/views.py
@@ -165,7 +165,11 @@ class ExportUsers(LoginRequiredMixin, UserPermissionRequiredMixin, View):
         ])
 
         # Write out all users visible to the current user
-        for user in User.objects.get_visible_users(request.user):
+        users = User.objects
+        users = users.get_visible_users(request.user)
+        if 'project' in request.GET:
+            users = users.filter(participants__project_id=request.GET['project'])
+        for user in users:
 
             # Remove the domain from the username
             username = user.username.split('@')[0]

--- a/haven/templates/projects/includes/project_detail_participants.html
+++ b/haven/templates/projects/includes/project_detail_participants.html
@@ -13,6 +13,10 @@
   {% if edit_user_href %}
     <a class="btn btn-primary btn-lg my-1" href="{{ edit_user_href }}">Edit Participants</a>
   {% endif %}
+  {% url_check 'identity:export_users' as export_users_href %}
+  {% if export_users_href %}
+    <a class="btn btn-primary btn-lg my-1" href="{{ export_users_href }}?project={{ project.id }}">Export UserCreate.csv</a>
+  {% endif %}
 {% endblock %}
 
 {% block details %}


### PR DESCRIPTION
This addresses #202 - on the project detail page there is now a button (for users with appropriate permissions) to export a CSV file of the participants for that project.

I considered adding this an an option to the page where the existing Export button is, either as a drop-down or as a interstitial page. I wasn't really sure if that would work too well though, given that we're expecting the number of projects to grow, but it should be straight-forward to add later if we think it's worthwhile.