### PR TITLE
Show deployed Azure version number when no git version can be fetched

### DIFF
--- a/haven/templates/home.html
+++ b/haven/templates/home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load haven %}
 
 {% block content %}
   <p>
@@ -27,6 +28,6 @@
   {% endif %}
 
   <nav class="navbar navbar-expand-md navbar-light bg-light fixed-bottom">
-    <span class="navbar-text ml-auto">Build {{ SOURCE_REVISION }}</span>
+    <span class="navbar-text ml-auto">Build {% version_number %}</span>
   </nav>
 {% endblock content %}


### PR DESCRIPTION
Quick fix for an issue with fetching the current version number using `django-revision`. This does not work in a deployed Azure app because it calls `git` which is not installed on an Azure App Service for Linux deployment container. This fix is to fetch the hash from a known file which Azure writes during deployment. 