### PR TITLE
View classification for project manager

### DIFF
--- a/haven/projects/roles.py
+++ b/haven/projects/roles.py
@@ -84,6 +84,7 @@ class UserProjectPermissions:
         add_work_packages     .  Y  Y   .  Y   .   .
         list_participants     .  Y  Y   .  Y   .   .
         edit_participants     .  Y  Y   .  Y   .   .
+        view_classification   .  .  Y   Y  Y   Y   .
         classify_data         .  .  .   Y  Y   Y   .
         classify_if_approved  .  .  .   .  .   Y   .
     '''

--- a/haven/templates/projects/includes/work_package_detail_datasets.html
+++ b/haven/templates/projects/includes/work_package_detail_datasets.html
@@ -19,7 +19,9 @@
   {% if can_classify %}
     {% url_check 'projects:classify_results' work_package.project.id work_package.id as classify_results_href %}
     {% url_check 'projects:classify_data' work_package.project.id work_package.id as classify_data_href %}
-    {% if has_classified and classify_results_href %}
+    {% if classify_results_href and not classify_data_href %}
+      <a class="btn btn-primary btn-lg" href="{{ classify_results_href }}">View Classification</a>
+    {% elif has_classified and classify_results_href %}
       <a class="btn btn-primary btn-lg" href="{{ classify_results_href }}">View Your Classification</a>
     {% elif classify_data_href %}
       <a class="btn btn-primary btn-lg" href="{{ classify_data_href }}">Classify Work Package</a>

--- a/haven/templates/projects/work_package_classify_results.html
+++ b/haven/templates/projects/work_package_classify_results.html
@@ -3,12 +3,13 @@
 {% load django_tables2 %}
 
 
-{% block h1_title %}Data Classification for {{ classification.work_package.name }}{% endblock %}
+{% block h1_title %}Data Classification for {{ work_package.name }}{% endblock %}
 
 {% block content %}
 
-{% with classification.work_package as work_package %}
-<p>You ({{ classification.created_by }}, {{classification.role|project_role_display}}) have classified this project as Tier {{ classification.tier }}</p>
+{% if classification %}
+  <p>You ({{ classification.created_by }}, {{classification.role|project_role_display}}) have classified this project as Tier {{ classification.tier }}</p>
+{% endif %}
 
 <h2>Overall classification</h2>
 {% if work_package.has_tier %}
@@ -21,7 +22,7 @@
     {% endfor %}
   </ul>
 {% elif work_package.tier_conflict %}
-<p>Users disagree on data tier</p>
+  <p>Users disagree on data tier</p>
 {% endif %}
 
 {% if not work_package.has_tier and other_classifications.exists %}
@@ -35,20 +36,22 @@
 
 {% if questions_table %}
   <h2>Classification answers</h2>
-  <p>You may modify your answers until overall classification has been completed. If you wish to do so, please use the links below. If you wish to delete your answers and start again, use the button at the bottom of the table.</p>
+  {% if classification %}
+    <p>You may modify your answers until overall classification has been completed. If you wish to do so, please use the links below. If you wish to delete your answers and start again, use the button at the bottom of the table.</p>
+  {% endif %}
   {% render_table questions_table %}
-  <p><a class="btn btn-primary btn-lg" href="{% url 'projects:classify_delete' work_package.project.id work_package.id %}">Delete My Classification</a></p>
+  {% if classification %}
+    <p><a class="btn btn-primary btn-lg" href="{% url 'projects:classify_delete' work_package.project.id work_package.id %}">Delete My Classification</a></p>
+  {% endif %}
 {% endif %}
-
-{% endwith %}
 
 {% endblock content %}
 
 {% block crumbs %}
   <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
   <li class="breadcrumb-item"><a href="{% url 'projects:list' %}">Projects</a></li>
-  <li class="breadcrumb-item"><a href="{% url 'projects:detail' classification.work_package.project.id %}">{{ classification.work_package.project.name }}</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'projects:detail' work_package.project.id %}">{{ work_package.project.name }}</a></li>
   <li class="breadcrumb-item">Work Packages</li>
-  <li class="breadcrumb-item"><a href="{{ classification.work_package.get_absolute_url }}">{{ classification.work_package.name }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ work_package.get_absolute_url }}">{{ work_package.name }}</a></li>
   <li class="breadcrumb-item active" aria-current="page">Data Classification</li>
 {% endblock crumbs %}


### PR DESCRIPTION
The second commit of this should fix #224. However, in preparation for that I also did some refactoring that was intended to make it easier to see what actions the different roles can do - previously it was fairly simple to answer questions like "Who can do X?", but harder to determine "What can Y do?" 

I'd very much like feedback on whether this actually achieves that though - I feel that the permissions table is clear (other may disagree), and it meant that adding a new permission was a one-line change, but can't decide if that outweighs the fact that getting it to work properly requires some non-obvious parsing and the use of `__getattr__` rather than explicit attributes.