### PR TITLE
Fix some inconsistent buttons (fix #279)

### DIFF
--- a/haven/core/templates/base.html
+++ b/haven/core/templates/base.html
@@ -31,16 +31,16 @@
             {% url_check 'identity:import_users' as import_users_href %}
             {% if add_user_href or import_users_href %}
               <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarUserDropdown" role="button" data-toggle="dropdown" aris-haspopup="true" aria-expanded="false">Create User</a>
+                <a class="nav-link dropdown-toggle" href="#" id="navbarUserDropdown" role="button" data-toggle="dropdown" aris-haspopup="true" aria-expanded="false">Add User</a>
                 <div class="dropdown-menu" aria-labelledby="navbarUserDropdown">
                   {% if add_user_href %}
-                    <a class="dropdown-item" href="{{ add_user_href }}">Create Single User</a>
+                    <a class="dropdown-item" href="{{ add_user_href }}">Add Single User</a>
                   {% endif %}
                   {% if import_users_href %}
                   <form style="display: contents" method="POST" action="{{ import_users_href }}" enctype="multipart/form-data">
                     {% csrf_token %}
                     <label class="dropdown-item">
-                      Import user list <input type="file" name="upload_file" id="upload_file" required="True" style="display: none;" onchange="this.form.submit()"/>
+                      Import User List <input type="file" name="upload_file" id="upload_file" required="True" style="display: none;" onchange="this.form.submit()"/>
                     </label>
                   </form>
                   {% endif %}

--- a/haven/core/templates/home.html
+++ b/haven/core/templates/home.html
@@ -22,7 +22,7 @@
     To classify a work package, each individual will go through a series of questions, to help understand the legal sensitivity of the data involved, and the consequences of a data breach.
   </p>
   {% if request.user.is_authenticated %}
-    <a class="btn btn-primary" href="{% url 'projects:list' %}">View your projects</a>
+    <a class="btn btn-primary" href="{% url 'projects:list' %}">View Your Projects</a>
   {% else %}
     <a class="btn btn-primary" href="{% url 'social:begin' 'azuread-tenant-oauth2' %}">Log In</a>
   {% endif %}

--- a/haven/identity/templates/identity/user_form.html
+++ b/haven/identity/templates/identity/user_form.html
@@ -9,7 +9,7 @@
     Edit User
     <h3>{{ subject_user.display_name }}</h3>
   {% else %}
-    Create User
+    Add User
   {% endif %}
 
 {% endblock %}
@@ -40,7 +40,7 @@
   {% if formset.initial_form_count == 0 %}
     <p>
       You may add the user to one or more existing projects now using the drop-downs below.
-      Alternatively, you can continue without adding users to a project – to do so, press "{{ editing | yesno:"Save Changes,Add User" }}" without selecting anything.
+      Alternatively, you can continue without adding users to a project – to do so, press "{{ editing | yesno:"Save User,Add User" }}" without selecting anything.
     </p>
   {% endif %}
 

--- a/haven/identity/templates/identity/user_list.html
+++ b/haven/identity/templates/identity/user_list.html
@@ -49,7 +49,7 @@
 {% block actions %}
   {% url_check 'identity:add_user' as add_user_href %}
   {% if add_user_href %}
-    <a class="btn btn-primary btn-lg mx-2 my-1" href="{{ add_user_href }}">Create user</a>
+    <a class="btn btn-primary btn-lg mx-2 my-1" href="{{ add_user_href }}">Add User</a>
   {% endif %}
 
   {% url_check "identity:import_users" as import_users_href %}

--- a/haven/identity/views.py
+++ b/haven/identity/views.py
@@ -13,11 +13,10 @@ from django.views.generic.edit import CreateView, UpdateView
 from phonenumber_field.phonenumber import PhoneNumber
 
 from haven.core.forms import InlineFormSetHelper
-from haven.projects.forms import ProjectsForUserInlineFormSet
-
 from haven.identity.forms import CreateUserForm, EditUserForm
 from haven.identity.mixins import UserPermissionRequiredMixin
 from haven.identity.models import User
+from haven.projects.forms import ProjectsForUserInlineFormSet
 
 
 class UserCreate(LoginRequiredMixin,
@@ -87,7 +86,7 @@ class UserEdit(LoginRequiredMixin,
 
     def get_context_data(self, **kwargs):
         helper = InlineFormSetHelper()
-        helper.add_input(Submit('submit', 'Save Changes'))
+        helper.add_input(Submit('submit', 'Save User'))
         helper.add_input(Submit('cancel', 'Cancel',
                                 css_class='btn-secondary',
                                 formnovalidate='formnovalidate'))

--- a/haven/projects/forms.py
+++ b/haven/projects/forms.py
@@ -74,7 +74,7 @@ class SaveCancelInlineFormSetHelper(InlineFormSetHelper):
 
 class ParticipantInlineFormSetHelper(SaveCancelInlineFormSetHelper):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('save_label', 'Save Changes')
+        kwargs.setdefault('save_label', 'Save Participants')
         super().__init__(*args, **kwargs)
         self.form_tag = False
         self.template = 'projects/includes/participants_inline_formset.html'

--- a/haven/projects/templates/projects/project_add_dataset.html
+++ b/haven/projects/templates/projects/project_add_dataset.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags %}
 {% load haven %}
 
-{% block h1_title %}Create Dataset{% endblock %}
+{% block h1_title %}Add Dataset{% endblock %}
 
 {% block content %}
 <p>

--- a/haven/projects/templates/projects/project_add_work_package.html
+++ b/haven/projects/templates/projects/project_add_work_package.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags %}
 {% load haven %}
 
-{% block h1_title %}Create Work Package{% endblock %}
+{% block h1_title %}Add Work Package{% endblock %}
 
 {% block content %}
 <p>

--- a/haven/projects/templates/projects/project_detail.html
+++ b/haven/projects/templates/projects/project_detail.html
@@ -24,7 +24,7 @@
   {% endif %}
   {% url_check 'projects:history' project.id as history_href %}
   {% if history_href %}
-    <a class="btn btn-primary btn-lg my-1" href="{{ history_href }}">History</a>
+    <a class="btn btn-primary btn-lg my-1" href="{{ history_href }}">View History</a>
   {% endif %}
   {% url_check 'projects:archive' project.id as archive_href %}
   {% if archive_href %}

--- a/haven/projects/templates/projects/project_form.html
+++ b/haven/projects/templates/projects/project_form.html
@@ -5,7 +5,7 @@
   {% if project %}
     Edit Project
   {% else %}
-    Create Project
+    Add Project
   {% endif %}
 {% endblock %}
 

--- a/haven/projects/templates/projects/project_list.html
+++ b/haven/projects/templates/projects/project_list.html
@@ -42,7 +42,7 @@
 {% block actions %}
   {% url_check 'projects:create' as create_project_url %}
   {% if create_project_url %}
-    <a class="btn btn-primary btn-lg" href="{{ create_project_url }}">Create Project</a>
+    <a class="btn btn-primary btn-lg" href="{{ create_project_url }}">Add Project</a>
   {% endif %}
 {% endblock actions %}
 

--- a/haven/projects/templates/projects/work_package_classify_data.html
+++ b/haven/projects/templates/projects/work_package_classify_data.html
@@ -30,12 +30,12 @@
   <div class="form-group form-row">
     <div class="col">
       {% if previous_question and previous_question != question %}
-        <a class="btn btn-secondary btn-sm" href="{% url 'projects:classify_data' project.id work_package.id previous_question.id %}">Previous question</a>
+        <a class="btn btn-secondary btn-sm" href="{% url 'projects:classify_data' project.id work_package.id previous_question.id %}">Previous Question</a>
       {% endif %}
       {% if starting_question and starting_question != question and starting_question != previous_question %}
-        <a class="btn btn-secondary btn-sm" href="{% url 'projects:classify_data' project.id work_package.id starting_question.id %}">Start over</a>
+        <a class="btn btn-secondary btn-sm" href="{% url 'projects:classify_data' project.id work_package.id starting_question.id %}">Start Over</a>
       {% endif %}
-      <a class="btn btn-secondary btn-sm" href="{{ work_package.get_absolute_url }}">Cancel classification</a>
+      <a class="btn btn-secondary btn-sm" href="{{ work_package.get_absolute_url }}">Cancel Classification</a>
     </div>
   </div>
 </form>

--- a/haven/projects/views.py
+++ b/haven/projects/views.py
@@ -405,7 +405,7 @@ class EditParticipant(
             for (role, name) in form.fields['role'].choices
             if project_permissions.can_assign_role(ProjectRole(role))
         ]
-        form.helper = SaveCancelFormHelper('Edit Participant')
+        form.helper = SaveCancelFormHelper('Save Participant')
         form.helper.form_tag = False
         return form
 
@@ -446,7 +446,7 @@ class ProjectCreateDataset(
     def get_form(self):
         form = super().get_form()
 
-        form.helper = SaveCancelFormHelper('Create Dataset')
+        form.helper = SaveCancelFormHelper('Add Dataset')
         form.helper.form_tag = False
         return form
 
@@ -535,7 +535,7 @@ class ProjectCreateWorkPackage(
     def get_form(self):
         form = super().get_form()
 
-        form.helper = SaveCancelFormHelper('Create Work Package')
+        form.helper = SaveCancelFormHelper('Add Work Package')
         form.helper.form_tag = False
         return form
 
@@ -677,7 +677,7 @@ class WorkPackageEditParticipants(
         return self.get_project_permissions().can_edit_participants
 
     def get_context_data(self, **kwargs):
-        helper = SaveCancelInlineFormSetHelper()
+        helper = SaveCancelInlineFormSetHelper('Save Participants')
         kwargs['helper'] = helper
         kwargs['formset'] = self.get_formset()
         kwargs['editing'] = True


### PR DESCRIPTION
This should fix #279. I decided to go through and take a look at all our buttons to see what the prevailing use was. In the majority of cases we used `"<Specific Verb> <Specific Noun>"`, e.g. `"Add Work Package"`, but there were some inconsistencies, all of which I changed to match the majority usage

* Between "Create" / "Add" -> All became "Add"
* Between "Edit" / "Save" -> "Save" was more common, and sometimes the same button was used for creating and editing, so I changed it to "Save" on all forms, although it's "Edit" on all links
* Some generic nouns (e.g. "Changes") -> Replaced with specific nouns
* Some missing verbs -> Added a verb (with the exception of "Yes/No/Previous Question" in the questionnaire which I left)
* Some buttons where only first word was capitalised -> All changed

(That means the specific example in #279 became "Save Participant", because that was closer to what most other pages used)
