### PR TITLE
Add option to clear all classifications (fix #298)

### DIFF
--- a/haven/projects/forms.py
+++ b/haven/projects/forms.py
@@ -338,6 +338,11 @@ class WorkPackageAddParticipantForm(SaveCreatorMixin, forms.ModelForm):
         self.fields['participant'].queryset = qs
 
 
+class WorkPackageClearForm(SaveCreatorMixin, forms.Form):
+    helper = SaveCancelFormHelper('Clear Classifications', 'btn-danger')
+    helper.form_method = 'POST'
+
+
 class WorkPackageClassifyDeleteForm(SaveCreatorMixin, forms.Form):
     helper = SaveCancelFormHelper('Delete Classification', 'btn-danger')
     helper.form_method = 'POST'

--- a/haven/projects/models.py
+++ b/haven/projects/models.py
@@ -234,6 +234,7 @@ class WorkPackage(CreatedByModel):
         delete_datasets      |   Y        .          . |
         view_classification  |   .        Y          Y |
         open_classification  |   Y        .          . | *
+        clear_classification |   .        Y          . |
         close_classification |   .        Y          . | *
         classify_data        |   .        Y          . |
         ''',
@@ -511,6 +512,12 @@ class WorkPackage(CreatedByModel):
         return self.classifications.filter(
             created_by=user
         )
+
+    def clear_classifications(self):
+        self.status = WorkPackageStatus.NEW.value
+        for c in self.classifications.all():
+            c.delete()
+        self.save()
 
     def show_approve_participants(self, approver):
         if not self.can_approve_participants:

--- a/haven/projects/roles.py
+++ b/haven/projects/roles.py
@@ -107,6 +107,7 @@ class UserPermissions:
         delete_work_package  |  Y   Y |  Y   .  .   .   . |     .
         view_classification  |  Y   Y |  Y   Y  Y   Y   . |     .
         open_classification  |  Y   Y |  Y   .  .   .   . |     .
+        clear_classification |  Y   Y |  Y   .  .   .   . |     .
         close_classification |  Y   Y |  Y   .  .   .   . |     .
         classify_data        |  .   . |  .   Y  Y   Y   . |     .
         ''',

--- a/haven/projects/templates/projects/work_package_clear.html
+++ b/haven/projects/templates/projects/work_package_clear.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+
+{% block h1_title %}Clear Classifications{% endblock %}
+
+{% block content %}
+<p>
+  Clearing the classifications will restore the ability to make changes such as adding and editing datasets.
+  However, all required participants will have to complete the classification process again.
+  Please confirm below if you would like to clear the existing classifications.
+</p>
+<form method="POST">
+  {% csrf_token %}
+  {% crispy form %}
+</form>
+
+{% endblock content %}
+
+{% block crumbs %}
+  <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'projects:list' %}">Projects</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'projects:detail' project.id %}">{{ project.name }}</a></li>
+  <li class="breadcrumb-item">Work Packages</li>
+  <li class="breadcrumb-item">{{ work_package.name }}</li>
+  <li class="breadcrumb-item active" aria-current="page">Clear Classifications</li>
+{% endblock crumbs %}

--- a/haven/projects/templates/projects/work_package_detail.html
+++ b/haven/projects/templates/projects/work_package_detail.html
@@ -41,6 +41,11 @@
     <a class="btn btn-primary btn-lg my-1" href="{{ delete_work_package_href }}">Delete Work Package</a>
   {% endif %}
 
+  {% url_check 'projects:classify_clear' project.id work_package.id as clear_work_package_href %}
+  {% if clear_work_package_href %}
+    <a class="btn btn-primary btn-lg my-1" href="{{ clear_work_package_href }}">Clear Classifications</a>
+  {% endif %}
+
   {% url_check 'projects:classify_open' work_package.project.id work_package.id as classify_open_href %}
   {% if classify_open_href %}
     <a class="btn btn-primary btn-lg" href="{{ classify_open_href }}">Open Classification</a>

--- a/haven/projects/urls.py
+++ b/haven/projects/urls.py
@@ -125,6 +125,12 @@ urlpatterns = [
     ),
 
     path(
+        '<int:project_pk>/work_packages/<int:pk>/classify_clear',
+        views.WorkPackageClear.as_view(),
+        name='classify_clear'
+    ),
+
+    path(
         '<int:project_pk>/work_packages/<int:pk>/classify_delete',
         views.WorkPackageClassifyDelete.as_view(),
         name='classify_delete'

--- a/tests/projects/test_models.py
+++ b/tests/projects/test_models.py
@@ -182,6 +182,28 @@ class TestWorkPackage:
         with pytest.raises(ValidationError):
             work_package.add_dataset(dataset, programme_manager)
 
+    def test_classification_reset(
+            self, classified_work_package, investigator, data_provider_representative):
+        work_package = classified_work_package(None)
+        dataset = work_package.datasets.first()
+
+        work_package.classify_as(3, investigator.user)
+        work_package.classify_as(3, data_provider_representative.user)
+
+        assert work_package.classifications.count() == 2
+        assert work_package.missing_classification_requirements == [
+            'Each Data Provider Representative for this Work Package needs to approve the Referee.'
+        ]
+
+        work_package.clear_classifications()
+        assert work_package.status == WorkPackageStatus.NEW.value
+        assert work_package.classifications.count() == 0
+        assert work_package.missing_classification_requirements == [
+            'An Investigator still needs to classify this Work Package.',
+            f"A Data Provider Representative for dataset {dataset.name} still needs to classify "
+            f"this Work Package.",
+        ]
+
     def test_classify_work_package_no_dataset(
             self, classified_work_package, investigator, data_provider_representative):
         work_package = classified_work_package(None)


### PR DESCRIPTION
This adds an option for the project manager to essentially 'reset' a work package, so that they can edit the description, add/edit datasets etc., but at the cost of requiring everyone to go through the classification process again