### PR TITLE
[WIP] Add login for AD guest users

### DIFF
--- a/haven/identity/forms.py
+++ b/haven/identity/forms.py
@@ -4,10 +4,9 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
-from haven.identity.roles import UserRole
-
 from haven.identity.mixins import SaveCreatorMixin
 from haven.identity.models import User
+from haven.identity.roles import UserRole
 
 
 class EditUserForm(UserKwargModelFormMixin, forms.ModelForm):
@@ -75,6 +74,15 @@ class EditUserForm(UserKwargModelFormMixin, forms.ModelForm):
 
 
 class CreateUserForm(SaveCreatorMixin, EditUserForm):
+
+    username = forms.CharField(
+        required=False,
+        help_text='For normal users, leave blank. For guest users, this must match the full '
+                  'username in Active Directory.'
+        )
+
+    class Meta(EditUserForm.Meta):
+        fields = ['first_name', 'last_name', 'mobile', 'email', 'role', 'username']
 
     def save(self, **kwargs):
         self.instance.generate_username()

--- a/haven/identity/models.py
+++ b/haven/identity/models.py
@@ -105,6 +105,9 @@ class User(AbstractUser):
         """
         Return a suitable username for this user
         """
+        if self.username:
+            return
+
         prefix = self.email_friendly(f"{self.first_name} {self.last_name}")
 
         # If the username already exists, try adding 2,3,4 etc
@@ -128,7 +131,7 @@ class User(AbstractUser):
         :return: `Participant` object or None if user is not involved in project
         """
         from haven.projects.models import Participant
-        
+
         try:
             return self.participants.get(project=project)
         except Participant.DoesNotExist:
@@ -154,7 +157,7 @@ class User(AbstractUser):
     def system_permissions(self):
         """
         Return object for determining the user's system-level permissions
-        
+
         :return: UserPermissions object describing user permissions
         """
 


### PR DESCRIPTION
This should allow guest users who have been added to Azure AD to login to the webapp, fixing #308.

It turns out some of what is documented in the issue is sort-of in place already. The `AzureADTenantOAuth2` backend we're using looks at the `sub` claim (which is unique to a particular user and client, and non-editable), and checks if that has already been seen for a `User`. If it has, that's the `User` to login as. That is essentially equivalent to what we wanted to do with `oid`.

If a user hasn't logged in before, that's when our `find_existing_user` method is called. I've updated that to use the `unique_name` in addition to the `upn`, which should allow it to match guest users. I've also allowed admins to set the username when creating a new user.

What I'm not sure about, and needs to be tested more thoroughly, is whether this opens up any possibilities for impersonation. If an AD account is deleted, then another one is created with the same credentials, they both get mapped to the same webapp user. With only internal users, where we use the UPN, that shouldn't really be an issue as it's up to the AD administrators if they want to reuse accounts. 

What I can't figure out is if the email for external users has the same restriction, or if a guest user would be able to change their email. The flow I'm thinking of is:

1. IT add user@external.com as a guest to the SHM AD
1. SM add user@external.com to the webapp
1. User changes their email to admin@turing.ac.uk in the remote AD
1. User logs in to the webapp. They've never logged in before, so it looks for a user whose username matches the email
1.  User sees admin's stuff

I don't know if Step 3 is actually possible or not though, and if it is whether it will be reflected in the SHM AD. I tried to test it, and only the username in the remote AD changed, but I can't be sure I didn't miss something. In my original proposal, it wouldn't have mattered too much, because I was proposing throwing an error if a user already had an `oid` associated with it. python-social-auth doesn't do that - it allows multiple social identities to be associated to a user, and I don't know if it's possible to change that.