### PR TITLE
434/additional dev documentation

### DIFF
--- a/docs/development/set-up-local-development.md
+++ b/docs/development/set-up-local-development.md
@@ -3,13 +3,13 @@
 These instructions are for running a local test instance of the management web application on your machine.
 
 ## Cloning the github repo
-Clone the github repo usnig the following command in your local terminal:
+Clone the github repo using the following command in your local terminal:
 
 ```
 git clone git@github.com:alan-turing-institute/data-classification-app.git
 ```
 
-After entering the folder containing the main repsitories' code (either through `cd`'ing into your folder containing the downloaded repo files, or using your OS' method) follow the quick docker setup below.
+After entering the folder containing the main repositories' code (either through `cd`'ing into your folder containing the downloaded repo files, or using your OS' method) follow the quick docker setup below.
 
 ## :whale: Quick setup with `docker`
 


### PR DESCRIPTION
## Description

This PR adds a few lines to`docs/development/set-up-local-development.md` to indicate that developers need to download git repo and enter the code repo's main folder in order to build docker deployment

Fixes #434 

Please delete options that are not relevant.
- [X] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation

Please provide any specific areas of feedback you're looking for from reviewers. 
